### PR TITLE
feat: Automate daily updates for live days counter

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,0 +1,31 @@
+name: Update README Day Counter
+
+on:
+  schedule:
+    # Runs every day at midnight UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Run update script
+        run: python update_readme.py
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "docs: update days counter"
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "github-actions[bot]@users.noreply.github.com"

--- a/update_readme.py
+++ b/update_readme.py
@@ -1,0 +1,45 @@
+import re
+
+def update_readme():
+    """
+    Updates the day counter in README.md by finding a number in the format (XX.XXX days),
+    incrementing it by one, and writing the updated content back to the file.
+    """
+    readme_path = 'README.md'
+    try:
+        with open(readme_path, 'r', encoding='utf-8') as file:
+            content = file.read()
+    except FileNotFoundError:
+        print(f"Error: {readme_path} not found.")
+        return
+
+    # Regex to find the pattern like (11.828 days)
+    pattern = re.compile(r'\((\d{2}\.\d{3}) days\)')
+
+    match = pattern.search(content)
+    if not match:
+        print("Could not find the day counter in the README.")
+        return
+
+    # Extracting the number, removing the dot, and incrementing
+    current_days_str = match.group(1)
+    current_days = int(current_days_str.replace('.', ''))
+    new_days = current_days + 1
+
+    # Formatting the new number back to XX.XXX format
+    new_days_str = str(new_days)
+    formatted_new_days = f"{new_days_str[:-3]}.{new_days_str[-3:]}"
+
+    # Replacing the old string with the new one
+    old_string = f'({current_days_str} days)'
+    new_string = f'({formatted_new_days} days)'
+
+    new_content = content.replace(old_string, new_string)
+
+    with open(readme_path, 'w', encoding='utf-8') as file:
+        file.write(new_content)
+
+    print(f"Successfully updated days from {current_days} to {new_days}.")
+
+if __name__ == "__main__":
+    update_readme()


### PR DESCRIPTION
I've introduced a GitHub Action workflow to automate the daily update of the 'live days' counter in my README.md file.

The solution consists of two parts:
- A Python script (`update_readme.py`) that reads the README, finds the day counter, increments it, and writes the file back.
- I also created a GitHub Actions workflow (`.github/workflows/update-readme.yml`) that runs daily at midnight UTC. This workflow executes the Python script and commits any changes it finds.

This automation will ensure the day counter is always up-to-date without you needing to do it manually.